### PR TITLE
support text accent in filter/config

### DIFF
--- a/guides/loot-filters.md
+++ b/guides/loot-filters.md
@@ -147,16 +147,17 @@ Match based on an item value. The value used for comparison is determined by plu
 
 The following table lists the supported display settings for matchers:
 
-| name             | value type              | description                                                                                          |
-|------------------|-------------------------|------------------------------------------------------------------------------------------------------|
-| hidden           | boolean                 | Whether this item is hidden in the overlay. When set to true, other display settings have no effect. |
-| color, textColor | string (ARGB color hex) | Color for the display text of the item.                                                              |
-| backgroundColor  | string (ARGB color hex) | Background color behind the display text.                                                            |
-| borderColor      | string (ARGB color hex) | Border color around the display text.                                                                |
-| showLootbeam     | boolean                 | Show an in-world lootbeam on the item's tile. The lootbeam color matches the configured text color.  |
-| showValue        | boolean                 | Include an item's value in the text overlay. The highest value between GE and HA price is chosen.    |
-| showDespawn      | boolean                 | Show a despawn timer, in game ticks, next to the text overlay.                                       |
-| notify           | boolean                 | Fire a system notification when the matched item drops.                                              |
+| name             | value type              | ordinal macros | description                                                                                          |
+|------------------|-------------------------|----------------|------------------------------------------------------------------------------------------------------|
+| hidden           | boolean                 |                | Whether this item is hidden in the overlay. When set to true, other display settings have no effect. |
+| color, textColor | string (ARGB color hex) |                | Color for the display text of the item.                                                              |
+| backgroundColor  | string (ARGB color hex) |                | Background color behind the display text.                                                            |
+| borderColor      | string (ARGB color hex) |                | Border color around the display text.                                                                |
+| showLootbeam     | boolean                 |                | Show an in-world lootbeam on the item's tile. The lootbeam color matches the configured text color.  |
+| showValue        | boolean                 |                | Include an item's value in the text overlay. The highest value between GE and HA price is chosen.    |
+| showDespawn      | boolean                 |                | Show a despawn timer, in game ticks, next to the text overlay.                                       |
+| notify           | boolean                 |                | Fire a system notification when the matched item drops.                                              |
+| textAccent       | enum                    | `TEXTACCENT_*` | Text accent to use:<li>1 = text shadow (default)</li><li>2 = outline</li>                            |
 
 ## Text macros
 

--- a/src/main/java/com/lootfilters/DisplayConfig.java
+++ b/src/main/java/com/lootfilters/DisplayConfig.java
@@ -1,5 +1,6 @@
 package com.lootfilters;
 
+import com.lootfilters.rule.TextAccent;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,6 +23,7 @@ public class DisplayConfig {
     private final boolean showValue;
     private final boolean showDespawn;
     private final boolean notify;
+    private final TextAccent textAccent;
 
     public DisplayConfig(Color textColor) {
         this.textColor = textColor;
@@ -32,5 +34,6 @@ public class DisplayConfig {
         showValue = false;
         showDespawn = false;
         notify = false;
+        textAccent = null;
     }
 }

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -1,5 +1,6 @@
 package com.lootfilters;
 
+import com.lootfilters.rule.TextAccent;
 import com.lootfilters.rule.ValueTier;
 import com.lootfilters.rule.ValueType;
 import net.runelite.client.config.Config;
@@ -102,7 +103,7 @@ public interface LootFiltersConfig extends Config {
     String displayOverrides = "displayOverrides";
     @ConfigItem(
             keyName = "alwaysShowValue",
-            name = "Always show value",
+            name = "Show value",
             description = "Always show item value.",
             section = displayOverrides,
             position = 0
@@ -110,12 +111,20 @@ public interface LootFiltersConfig extends Config {
     default boolean alwaysShowValue() { return false; }
     @ConfigItem(
             keyName = "alwaysShowDespawn",
-            name = "Always show despawn",
+            name = "Show despawn",
             description = "Always show item despawn timers.",
             section = displayOverrides,
             position = 1
     )
     default boolean alwaysShowDespawn() { return false; }
+    @ConfigItem(
+            keyName = "textAccent",
+            name = "Text accent",
+            description = "Text accent type.",
+            section = displayOverrides,
+            position = 2
+    )
+    default TextAccent textAccent() { return TextAccent.USE_FILTER; }
 
     @ConfigSection(
             name = "Item lists",

--- a/src/main/java/com/lootfilters/LootFiltersOverlay.java
+++ b/src/main/java/com/lootfilters/LootFiltersOverlay.java
@@ -1,5 +1,6 @@
 package com.lootfilters;
 
+import com.lootfilters.rule.TextAccent;
 import net.runelite.api.Client;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
@@ -97,6 +98,7 @@ public class LootFiltersOverlay extends Overlay {
                 text.setFont(getRunescapeSmallFont());
                 text.setColor(match.isHidden() ? COLOR_HIDDEN : match.getTextColor());
                 text.setPosition(new Point(textPoint.getX(), textPoint.getY() - currentOffset));
+                text.setOutline(match.getTextAccent() != null && match.getTextAccent() == TextAccent.OUTLINE);
 
                 var boundingBox = new Rectangle(
                         textPoint.getX() - BOX_PAD, textPoint.getY() - currentOffset - textHeight - BOX_PAD,

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -11,6 +11,7 @@ import com.lootfilters.rule.ItemQuantityRule;
 import com.lootfilters.rule.ItemValueRule;
 import com.lootfilters.rule.OrRule;
 import com.lootfilters.rule.Rule;
+import com.lootfilters.rule.TextAccent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -158,6 +159,8 @@ public class Parser {
                     builder.showDespawn(assign[1].expectBoolean()); break;
                 case "notify":
                     builder.notify(assign[1].expectBoolean()); break;
+                case "textAccent":
+                    builder.textAccent(TextAccent.fromOrdinal(assign[1].expectInt())); break;
                 default:
                     throw new ParseException("unexpected identifier in display config block", assign[0]);
             }

--- a/src/main/java/com/lootfilters/rule/TextAccent.java
+++ b/src/main/java/com/lootfilters/rule/TextAccent.java
@@ -1,0 +1,24 @@
+package com.lootfilters.rule;
+
+import com.lootfilters.lang.ParseException;
+
+public enum TextAccent {
+    USE_FILTER, SHADOW, OUTLINE;
+
+    public static TextAccent fromOrdinal(int o) {
+        switch (o) {
+            case 1: return SHADOW;
+            case 2: return OUTLINE;
+            default: throw new ParseException("unrecognized TextAccent ordinal " + o);
+        }
+    }
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case USE_FILTER: return "use filter";
+            case SHADOW: return "shadow";
+            default: return "outline";
+        }
+    }
+}

--- a/src/main/java/com/lootfilters/util/FilterUtil.java
+++ b/src/main/java/com/lootfilters/util/FilterUtil.java
@@ -3,6 +3,7 @@ package com.lootfilters.util;
 import com.lootfilters.LootFilter;
 import com.lootfilters.LootFiltersConfig;
 import com.lootfilters.MatcherConfig;
+import com.lootfilters.rule.TextAccent;
 import com.lootfilters.rule.ValueTier;
 
 import java.util.ArrayList;
@@ -59,6 +60,13 @@ public class FilterUtil {
             matchersWithConfig = matchersWithConfig.stream()
                     .map(it -> new MatcherConfig(it.getRule(), it.getDisplay().toBuilder()
                             .showDespawn(true)
+                            .build()))
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+        if (config.textAccent().ordinal() > TextAccent.USE_FILTER.ordinal()) {
+            matchersWithConfig = matchersWithConfig.stream()
+                    .map(it -> new MatcherConfig(it.getRule(), it.getDisplay().toBuilder()
+                            .textAccent(config.textAccent())
                             .build()))
                     .collect(Collectors.toCollection(ArrayList::new));
         }

--- a/src/main/resources/com/lootfilters/scripts/preamble.rs2f
+++ b/src/main/resources/com/lootfilters/scripts/preamble.rs2f
@@ -30,3 +30,6 @@
 
 #define RARE(_name, _color) if (name:_name) { color = _color; borderColor = _color; }
 #define RARE2(_name, _color) if (name:_name) { color = _color; borderColor = _color; backgroundColor = "80000000"; showLootbeam = true; }
+
+#define TEXTACCENT_SHADOW 1
+#define TEXTACCENT_OUTLINE 2


### PR DESCRIPTION
cc @hawkins

Add "text accent" support, available as both a global display config and rule-level setting:
![image](https://github.com/user-attachments/assets/eadf4502-79da-4486-8851-3fb0e6c5380c)

* use filter = plugin defers to rule-level settings (default is shadow)
* shadow = force text shadow
* outline = force text outline

Configured at the filter level w/ the `textAccent` property:
* `1` / `TEXTACCENT_SHADOW` = shadow
* `2` / `TEXTACCENT_OUTLINE` = outline

```
HIGHLIGHT("bones", GREEN)
if (name:"coins") {
  color = YELLOW;
  textAccent = 2;
}
```

![image](https://github.com/user-attachments/assets/cac83778-51ca-490a-9846-67958297d2cc)
