### PR TITLE
add item spawn filter

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -41,17 +41,25 @@ public interface LootFiltersConfig extends Config {
     @ConfigItem(
             keyName = "ownershipFilter",
             name = "Ownership filter",
-            description = "When enabled, filters out any items you cannot pick up. This filter is ABSOLUTE, and overrides ALL other rules, including default highlight/hide, default item value rules, and the active loot filter.",
+            description = "When enabled, filters out any items you cannot pick up. This filter overrides ALL other rules/config.",
             section = general,
             position = 3
     )
     default boolean ownershipFilter() { return false; }
     @ConfigItem(
+            keyName = "itemSpawnFilter",
+            name = "Item spawn filter",
+            description = "When enabled, filters out item spawns (world spawns, ashes from fire, etc). This filter overrides ALL other rules/config.",
+            section = general,
+            position = 4
+    )
+    default boolean itemSpawnFilter() { return false; }
+    @ConfigItem(
             keyName = "valueType",
             name = "Value type",
             description = "The type of item value to use for rules and text overlay.",
             section = general,
-            position = 4
+            position = 5
     )
     default ValueType valueType() { return ValueType.HIGHEST; }
 

--- a/src/main/java/com/lootfilters/MatcherConfig.java
+++ b/src/main/java/com/lootfilters/MatcherConfig.java
@@ -44,6 +44,18 @@ public class MatcherConfig {
         return new MatcherConfig(rule, display);
     }
 
+    public static MatcherConfig itemSpawnFilter(boolean enabled) {
+        var rule = new Rule("") {
+            @Override public boolean test(LootFiltersPlugin plugin, TileItem item) {
+                return enabled && item.getOwnership() == TileItem.OWNERSHIP_NONE;
+            }
+        };
+        var display = DisplayConfig.builder()
+                .hidden(true)
+                .build();
+        return new MatcherConfig(rule, display);
+    }
+
     public static MatcherConfig showUnmatched(boolean enabled) {
         var rule = new Rule("") {
             @Override public boolean test(LootFiltersPlugin plugin, TileItem item) {

--- a/src/main/java/com/lootfilters/util/FilterUtil.java
+++ b/src/main/java/com/lootfilters/util/FilterUtil.java
@@ -23,6 +23,7 @@ public class FilterUtil {
     public static LootFilter withConfigMatchers(LootFilter filter, LootFiltersConfig config) {
         var matchersWithConfig = new ArrayList<MatcherConfig>();
         matchersWithConfig.add(MatcherConfig.ownershipFilter(config.ownershipFilter()));
+        matchersWithConfig.add(MatcherConfig.itemSpawnFilter(config.itemSpawnFilter()));
 
         matchersWithConfig.addAll(filter.getMatchers());
 


### PR DESCRIPTION
Closes #12 

cc @AbsolutePhoenix

Adds "item spawn filter" to config:

![image](https://github.com/user-attachments/assets/6136a469-1773-40d8-9a2d-0360f0d5bee1)

Going with two toggles here over the ground items enum version of <all, lootable, drops> - since two toggles gives us more overall options - it basically gives you individual control over lootable/drops rather than having to lock into one mode.