### PR TITLE
Update loot-filters.md with correct url for OSRS version of mejrs' map

### DIFF
--- a/guides/loot-filters.md
+++ b/guides/loot-filters.md
@@ -85,7 +85,7 @@ activation area:
 [x0, y0, z0, x1, y1, z1]
 ```
 
-There are several excellent web-based tools for finding map coordinates, such as https://mejrs.github.io/.
+There are several excellent web-based tools for finding map coordinates, such as https://mejrs.github.io/osrs.
 
 For example, the coordinate pair `[2240, 4032, 0, 2303, 4095, 0]` describes the area for Vorkath.
 


### PR DESCRIPTION
Updated the url to mejrs' map such that it points to the OSRS version, instead of the RS3 version.