### PR TITLE
enhanced color literal support

### DIFF
--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -3,7 +3,17 @@ package com.lootfilters.lang;
 import com.lootfilters.DisplayConfig;
 import com.lootfilters.LootFilter;
 import com.lootfilters.MatcherConfig;
-import com.lootfilters.rule.*;
+import com.lootfilters.rule.AndRule;
+import com.lootfilters.rule.Comparator;
+import com.lootfilters.rule.FontType;
+import com.lootfilters.rule.ItemIdRule;
+import com.lootfilters.rule.ItemNameRule;
+import com.lootfilters.rule.ItemQuantityRule;
+import com.lootfilters.rule.ItemTradeableRule;
+import com.lootfilters.rule.ItemValueRule;
+import com.lootfilters.rule.OrRule;
+import com.lootfilters.rule.Rule;
+import com.lootfilters.rule.TextAccent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +36,6 @@ import static com.lootfilters.lang.Token.Type.META;
 import static com.lootfilters.lang.Token.Type.OP_AND;
 import static com.lootfilters.lang.Token.Type.OP_OR;
 import static com.lootfilters.lang.Token.Type.STMT_END;
-import static com.lootfilters.util.TextUtil.parseArgb;
 
 // Parser somewhat mixes canonical stages 2 (parse) and 3/4 (syntax/semantic analysis) but the filter language is
 // restricted enough that it should be fine for now.
@@ -136,11 +145,11 @@ public class Parser {
             switch (assign[0].getValue()) {
                 case "textColor":
                 case "color":
-                    builder.textColor(parseArgb(assign[1].expectString())); break;
+                    builder.textColor(assign[1].expectColor()); break;
                 case "backgroundColor":
-                    builder.backgroundColor(parseArgb(assign[1].expectString())); break;
+                    builder.backgroundColor(assign[1].expectColor()); break;
                 case "borderColor":
-                    builder.borderColor(parseArgb(assign[1].expectString())); break;
+                    builder.borderColor(assign[1].expectColor()); break;
                 case "hidden":
                     builder.hidden(assign[1].expectBoolean()); break;
                 case "showLootbeam":
@@ -155,14 +164,14 @@ public class Parser {
                 case "textAccent":
                     builder.textAccent(TextAccent.fromOrdinal(assign[1].expectInt())); break;
                 case "textAccentColor":
-                    builder.textAccentColor(parseArgb(assign[1].expectString())); break;
+                    builder.textAccentColor(assign[1].expectColor()); break;
                 case "lootbeamColor":
                 case "lootBeamColor":
-                    builder.lootbeamColor(parseArgb(assign[1].expectString())); break;
+                    builder.lootbeamColor(assign[1].expectColor()); break;
                 case "fontType":
                     builder.fontType(FontType.fromOrdinal(assign[1].expectInt())); break;
                 case "menuTextColor":
-                    builder.menuTextColor(parseArgb(assign[1].expectString())); break;
+                    builder.menuTextColor(assign[1].expectColor()); break;
                 default:
                     throw new ParseException("unexpected identifier in display config block", assign[0]);
             }

--- a/src/main/java/com/lootfilters/lang/Token.java
+++ b/src/main/java/com/lootfilters/lang/Token.java
@@ -2,6 +2,9 @@ package com.lootfilters.lang;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import net.runelite.client.util.ColorUtil;
+
+import java.awt.Color;
 
 @Value
 @RequiredArgsConstructor
@@ -47,6 +50,18 @@ public class Token {
             throw new ParseException("unexpected non-string token", this);
         }
         return value;
+    }
+
+    public Color expectColor() {
+        if (type != Type.LITERAL_STRING) {
+            throw new ParseException("unexpected non-string token", this);
+        }
+
+        var color = ColorUtil.fromHex(value);
+        if (color == null) {
+            throw new ParseException("unexpected non-color string", this);
+        }
+        return color;
     }
 
     public boolean expectBoolean() {

--- a/src/main/java/com/lootfilters/serde/ColorDeserializer.java
+++ b/src/main/java/com/lootfilters/serde/ColorDeserializer.java
@@ -4,15 +4,14 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import net.runelite.client.util.ColorUtil;
 
 import java.awt.Color;
 import java.lang.reflect.Type;
 
-import static com.lootfilters.util.TextUtil.parseArgb;
-
 public class ColorDeserializer implements JsonDeserializer<Color> {
     @Override
     public Color deserialize(JsonElement elem, Type type, JsonDeserializationContext ctx) throws JsonParseException {
-        return parseArgb(elem.getAsString());
+        return ColorUtil.fromHex(elem.getAsString());
     }
 }

--- a/src/main/java/com/lootfilters/util/TextUtil.java
+++ b/src/main/java/com/lootfilters/util/TextUtil.java
@@ -1,6 +1,5 @@
 package com.lootfilters.util;
 
-import java.awt.Color;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -27,10 +26,6 @@ public class TextUtil {
 
     public static boolean isLegalIdent(char c) {
         return c == '_' || isAlpha(c) || isNumeric(c);
-    }
-
-    public static Color parseArgb(String argb) {
-        return new Color(Long.decode("0x" + argb).intValue(), true);
     }
 
     public static String abbreviate(int value) {

--- a/src/test/resources/com/lootfilters/parser-test.rs2f
+++ b/src/test/resources/com/lootfilters/parser-test.rs2f
@@ -9,18 +9,18 @@ meta {
 
 // insane items
 if (value:>10000000) {
-    color="ffff8000";
+    color="ff8000";
     showLootbeam=true; // lootbeam
 }
 if (value:>1000000) {
-    color="ffa335ee";
+    color="#a335ee";
     showLootbeam=true;
 }
 if (value:>100000) {
     color="ff0070dd";
 }
 if (value:>10000) {
-    color="ff1eff00";
+    color="#ff1eff00";
 }
 // end comment
 


### PR DESCRIPTION
Support all of the following:
* `rrggbb`
* `#rrggbb`
* `aarrggbb`
* `#aarrggbb`

and theoretically more (it's based on whatever the underlying ColorUtil.fromHex gives us, which appears to also include hex-prefix strings i.e. `0xrrggbb` (but I didn't test that)