### PR TITLE
feat: add stackable & noted rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Filters can match on various characteristics of an item:
 * quantity of stacked items
 * whether an item is tradeable
 * whether an item is stackable
+* whether an item is noted
 
 Items that match a particular set of conditions can be configured to display in various ways:
 * show/hide

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Filters can match on various characteristics of an item:
 * value
 * quantity of stacked items
 * whether an item is tradeable
+* whether an item is stackable
 
 Items that match a particular set of conditions can be configured to display in various ways:
 * show/hide

--- a/guides/loot-filters.md
+++ b/guides/loot-filters.md
@@ -148,6 +148,10 @@ Match based on whether an item is tradeable.
 
 Match based on whether an item is stackable (noted, coins, fishbait etc.).
 
+#### noted `noted:true` or `noted:false`
+
+Match based on whether an item is a note.
+
 ### Display settings
 
 The following table lists the supported display settings for matchers:

--- a/guides/loot-filters.md
+++ b/guides/loot-filters.md
@@ -144,6 +144,10 @@ Match based on an item value. The value used for comparison is determined by plu
 
 Match based on whether an item is tradeable.
 
+#### stackable `stackable:true` or `stackable:false`
+
+Match based on whether an item is stackable (noted, coins, fishbait etc.).
+
 ### Display settings
 
 The following table lists the supported display settings for matchers:

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -185,6 +185,8 @@ public class Parser {
                 return parseItemValueRule();
             case "tradeable":
                 return parseItemTradeableRule();
+            case "stackable":
+                return parseItemStackableRule();
             default:
                 throw new ParseException("unknown rule identifier", first);
         }
@@ -217,6 +219,11 @@ public class Parser {
         return new ItemTradeableRule((op.expectBoolean()));
     }
 
+    private ItemStackableRule parseItemStackableRule() {
+        var op = tokens.take();
+        return new ItemStackableRule((op.expectBoolean()));
+    }
+
     private Rule buildRule(List<Rule> postfix) {
         var operands = new Stack<Rule>();
         for (var rule : postfix) {
@@ -224,7 +231,8 @@ public class Parser {
                     || rule instanceof ItemNameRule
                     || rule instanceof ItemQuantityRule
                     || rule instanceof ItemValueRule
-                    || rule instanceof ItemTradeableRule) {
+                    || rule instanceof ItemTradeableRule
+                    || rule instanceof ItemStackableRule) {
                 operands.push(rule);
             } else if (rule instanceof AndRule) {
                 operands.push(new AndRule(operands.pop(), operands.pop()));

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -187,6 +187,8 @@ public class Parser {
                 return parseItemTradeableRule();
             case "stackable":
                 return parseItemStackableRule();
+            case "noted":
+                return parseItemNotedRule();
             default:
                 throw new ParseException("unknown rule identifier", first);
         }
@@ -224,6 +226,11 @@ public class Parser {
         return new ItemStackableRule((op.expectBoolean()));
     }
 
+    private ItemNotedRule parseItemNotedRule() {
+        var op = tokens.take();
+        return new ItemNotedRule((op.expectBoolean()));
+    }
+
     private Rule buildRule(List<Rule> postfix) {
         var operands = new Stack<Rule>();
         for (var rule : postfix) {
@@ -232,7 +239,8 @@ public class Parser {
                     || rule instanceof ItemQuantityRule
                     || rule instanceof ItemValueRule
                     || rule instanceof ItemTradeableRule
-                    || rule instanceof ItemStackableRule) {
+                    || rule instanceof ItemStackableRule
+                    || rule instanceof ItemNotedRule) {
                 operands.push(rule);
             } else if (rule instanceof AndRule) {
                 operands.push(new AndRule(operands.pop(), operands.pop()));

--- a/src/main/java/com/lootfilters/rule/ItemNotedRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemNotedRule.java
@@ -1,0 +1,23 @@
+package com.lootfilters.rule;
+
+import com.lootfilters.LootFiltersPlugin;
+import lombok.EqualsAndHashCode;
+import net.runelite.api.TileItem;
+
+@EqualsAndHashCode(callSuper = false)
+public class ItemNotedRule extends Rule {
+    private final boolean target;
+
+    public ItemNotedRule(boolean target) {
+        super("item_noted");
+        this.target = target;
+    }
+
+    @Override
+    public boolean test(LootFiltersPlugin plugin, TileItem item) {
+        var comp = plugin.getItemManager().getItemComposition(item.getId());
+
+        boolean isNote = comp.getNote() != -1;
+        return target == isNote;
+    }
+}

--- a/src/main/java/com/lootfilters/rule/ItemStackableRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemStackableRule.java
@@ -21,9 +21,7 @@ public class ItemStackableRule extends Rule {
         }
 
         var comp = plugin.getItemManager().getItemComposition(item.getId());
-        var linkedComp = plugin.getItemManager().getItemComposition(comp.getLinkedNoteId());
-        return target
-                ? comp.isStackable() || linkedComp.isStackable()
-                : !comp.isStackable() && !linkedComp.isStackable();
+
+        return target == comp.isStackable();
     }
 }

--- a/src/main/java/com/lootfilters/rule/ItemStackableRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemStackableRule.java
@@ -1,0 +1,29 @@
+package com.lootfilters.rule;
+
+import com.lootfilters.LootFiltersPlugin;
+import lombok.EqualsAndHashCode;
+import net.runelite.api.ItemID;
+import net.runelite.api.TileItem;
+
+@EqualsAndHashCode(callSuper = false)
+public class ItemStackableRule extends Rule {
+    private final boolean target;
+
+    public ItemStackableRule(boolean target) {
+        super("item_stackable");
+        this.target = target;
+    }
+
+    @Override
+    public boolean test(LootFiltersPlugin plugin, TileItem item) {
+        if (item.getId() == ItemID.COINS_995 || item.getId() == ItemID.PLATINUM_TOKEN) {
+            return target;
+        }
+
+        var comp = plugin.getItemManager().getItemComposition(item.getId());
+        var linkedComp = plugin.getItemManager().getItemComposition(comp.getLinkedNoteId());
+        return target
+                ? comp.isStackable() || linkedComp.isStackable()
+                : !comp.isStackable() && !linkedComp.isStackable();
+    }
+}

--- a/src/main/java/com/lootfilters/rule/ItemStackableRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemStackableRule.java
@@ -16,10 +16,6 @@ public class ItemStackableRule extends Rule {
 
     @Override
     public boolean test(LootFiltersPlugin plugin, TileItem item) {
-        if (item.getId() == ItemID.COINS_995 || item.getId() == ItemID.PLATINUM_TOKEN) {
-            return target;
-        }
-
         var comp = plugin.getItemManager().getItemComposition(item.getId());
 
         return target == comp.isStackable();

--- a/src/test/java/com/lootfilters/ParserTest.java
+++ b/src/test/java/com/lootfilters/ParserTest.java
@@ -43,6 +43,10 @@ public class ParserTest {
                 new MatcherConfig(new ItemTradeableRule(false),
                         DisplayConfig.builder()
                                 .textColor(new Color(0xff,0x80,0x00, 0xff))
+                                .build()),
+                new MatcherConfig(new ItemStackableRule(false),
+                        DisplayConfig.builder()
+                                .textColor(new Color(0xff,0x90,0x00, 0xff))
                                 .build())
         );
         var expect = new LootFilter(expectName, expectDesc, expectArea, expectMatchers);

--- a/src/test/java/com/lootfilters/ParserTest.java
+++ b/src/test/java/com/lootfilters/ParserTest.java
@@ -3,9 +3,7 @@ package com.lootfilters;
 import com.lootfilters.lang.Lexer;
 import com.lootfilters.lang.Parser;
 import com.lootfilters.rule.Comparator;
-import com.lootfilters.rule.ItemStackableRule;
-import com.lootfilters.rule.ItemTradeableRule;
-import com.lootfilters.rule.ItemValueRule;
+import com.lootfilters.rule.*;
 import org.junit.Test;
 
 import java.awt.Color;
@@ -48,6 +46,10 @@ public class ParserTest {
                 new MatcherConfig(new ItemStackableRule(false),
                         DisplayConfig.builder()
                                 .textColor(new Color(0xff,0x90,0x00, 0xff))
+                                .build()),
+                new MatcherConfig(new ItemNotedRule(false),
+                        DisplayConfig.builder()
+                                .textColor(new Color(0xff,0x95,0x00, 0xff))
                                 .build())
         );
         var expect = new LootFilter(expectName, expectDesc, expectArea, expectMatchers);

--- a/src/test/java/com/lootfilters/ParserTest.java
+++ b/src/test/java/com/lootfilters/ParserTest.java
@@ -3,6 +3,7 @@ package com.lootfilters;
 import com.lootfilters.lang.Lexer;
 import com.lootfilters.lang.Parser;
 import com.lootfilters.rule.Comparator;
+import com.lootfilters.rule.ItemStackableRule;
 import com.lootfilters.rule.ItemTradeableRule;
 import com.lootfilters.rule.ItemValueRule;
 import org.junit.Test;

--- a/src/test/resources/com/lootfilters/parser-test.rs2f
+++ b/src/test/resources/com/lootfilters/parser-test.rs2f
@@ -27,3 +27,7 @@ if (value:>10000) {
 if (tradeable:false) {
     color="ffff8000";
 }
+
+if (stackable:false) {
+    color="ffff9000";
+}

--- a/src/test/resources/com/lootfilters/parser-test.rs2f
+++ b/src/test/resources/com/lootfilters/parser-test.rs2f
@@ -31,3 +31,7 @@ if (tradeable:false) {
 if (stackable:false) {
     color="ffff9000";
 }
+
+if (noted:false) {
+    color="ffff9500";
+}


### PR DESCRIPTION
Closes #6.

I wasn't sure if we wanted to be able to differentiate based on noted vs. stackable (like fish bait vs. notes for instance), so I've implemented both which should provide more freedom.