### PR TITLE
support list in name rule

### DIFF
--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -212,9 +212,15 @@ public class Parser {
         return new ItemIdRule(id.expectInt());
     }
 
-    private ItemNameRule parseItemNameRule() {
-        var name = tokens.takeExpect(LITERAL_STRING);
-        return new ItemNameRule(name.getValue());
+    private Rule parseItemNameRule() {
+        if (tokens.peek().is(LITERAL_STRING)) {
+            return new ItemNameRule(tokens.take().expectString());
+        } else if (tokens.peek().is(LIST_START)) {
+            var block = tokens.take(LIST_START, LIST_END, true);
+            return new ItemNameRule(block.expectStringList());
+        } else {
+            throw new ParseException("parse item name: unexpected argument token", tokens.peek());
+        }
     }
 
     private ItemQuantityRule parseItemQuantityRule() {

--- a/src/main/java/com/lootfilters/lang/TokenStream.java
+++ b/src/main/java/com/lootfilters/lang/TokenStream.java
@@ -203,6 +203,35 @@ public class TokenStream {
         return args;
     }
 
+    /**
+     * Attempt to parse the entire token stream as a list of strings.
+     */
+    public List<String> expectStringList() {
+        var strings = new ArrayList<String>();
+
+        takeExpect(Token.Type.LIST_START);
+        while (isNotEmpty()) {
+            if (peek().is(Token.Type.LIST_END)) {
+                return strings;
+            }
+
+            strings.add(take().expectString());
+            if (peek().is(Token.Type.COMMA)) {
+                take();
+            } else if (peek().is(Token.Type.LIST_END)) {
+                take();
+                break;
+            } else {
+                throw new ParseException("unexpected token in list", peek());
+            }
+        }
+        if (isNotEmpty()) {
+            throw new ParseException("unterminated list");
+        }
+
+        return strings;
+    }
+
     public boolean isNotEmpty() { // this doesn't _currently_ need a version that checks non-semantic
         return tokens.stream().anyMatch(Token::isSemantic);
     }

--- a/src/main/java/com/lootfilters/rule/ItemNameRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemNameRule.java
@@ -4,23 +4,34 @@ import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
 import net.runelite.api.TileItem;
 
+import java.util.List;
+
 @EqualsAndHashCode(callSuper = false)
 public class ItemNameRule extends Rule {
-    private final String name;
+    private final List<String> names;
+
+    public ItemNameRule(List<String> names) {
+        super("item_name");
+        this.names = names;
+    }
 
     public ItemNameRule(String name) {
         super("item_name");
-        this.name = name;
+        this.names = List.of(name);
     }
 
     @Override
     public boolean test(LootFiltersPlugin plugin, TileItem item) {
         var itemName = plugin.getItemName(item.getId());
-        if (name.startsWith("*")) {
-            return itemName.toLowerCase().endsWith(name.toLowerCase().substring(1));
-        } else if (name.endsWith("*")) {
-            return itemName.toLowerCase().startsWith(name.toLowerCase().substring(0, name.length() - 1));
+        return names.stream().anyMatch(it -> test(itemName, it));
+    }
+
+    private boolean test(String name, String target) {
+        if (target.startsWith("*")) {
+            return name.toLowerCase().endsWith(target.toLowerCase().substring(1));
+        } else if (target.endsWith("*")) {
+            return name.toLowerCase().startsWith(target.toLowerCase().substring(0, target.length() - 1));
         }
-        return itemName.equalsIgnoreCase(name);
+        return name.equalsIgnoreCase(target);
     }
 }


### PR DESCRIPTION
Closes #59

```
#define names [\
"max*",\
"*edle"]

// Here's an example:
if (name:names) {
  color = MAGENTA;
}

if (name:"holy wrench") {color = BLUE;}
```
![image](https://github.com/user-attachments/assets/3650cd6b-a1f5-4658-8e23-8c93d688dffa)

