### PR TITLE
Fix: InaccessibleObjectException for java 16+

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersPanel.java
+++ b/src/main/java/com/lootfilters/LootFiltersPanel.java
@@ -1,5 +1,32 @@
 package com.lootfilters;
 
+import com.lootfilters.lang.CompileException;
+import com.lootfilters.lang.Sources;
+import lombok.SneakyThrows;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.PluginPanel;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+import java.util.ArrayList;
+
 import static com.lootfilters.util.CollectionUtil.append;
 import static com.lootfilters.util.FilterUtil.configToFilterSource;
 import static com.lootfilters.util.TextUtil.quote;
@@ -7,20 +34,6 @@ import static javax.swing.JOptionPane.showConfirmDialog;
 import static javax.swing.JOptionPane.showInputDialog;
 import static javax.swing.SwingUtilities.invokeLater;
 import static net.runelite.client.util.ImageUtil.loadImageResource;
-
-import com.lootfilters.lang.CompileException;
-import com.lootfilters.lang.Sources;
-import java.awt.*;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.event.ActionEvent;
-import java.io.IOException;
-import java.util.ArrayList;
-import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import lombok.SneakyThrows;
-import net.runelite.client.ui.FontManager;
-import net.runelite.client.ui.PluginPanel;
 
 public class LootFiltersPanel extends PluginPanel {
     private static final String NONE_ITEM = "<none>";

--- a/src/main/java/com/lootfilters/LootFiltersPanel.java
+++ b/src/main/java/com/lootfilters/LootFiltersPanel.java
@@ -1,40 +1,26 @@
 package com.lootfilters;
 
-import com.lootfilters.lang.CompileException;
-import com.lootfilters.lang.Sources;
-import lombok.SneakyThrows;
-import net.runelite.client.ui.FontManager;
-import net.runelite.client.ui.PluginPanel;
-
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import java.awt.Color;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.Toolkit;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.event.ActionEvent;
-import java.io.IOException;
-import java.util.ArrayList;
-
 import static com.lootfilters.util.CollectionUtil.append;
 import static com.lootfilters.util.FilterUtil.configToFilterSource;
 import static com.lootfilters.util.TextUtil.quote;
-import static java.util.Collections.emptyList;
 import static javax.swing.JOptionPane.showConfirmDialog;
 import static javax.swing.JOptionPane.showInputDialog;
 import static javax.swing.SwingUtilities.invokeLater;
 import static net.runelite.client.util.ImageUtil.loadImageResource;
+
+import com.lootfilters.lang.CompileException;
+import com.lootfilters.lang.Sources;
+import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+import java.util.ArrayList;
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import lombok.SneakyThrows;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.PluginPanel;
 
 public class LootFiltersPanel extends PluginPanel {
     private static final String NONE_ITEM = "<none>";
@@ -255,7 +241,7 @@ public class LootFiltersPanel extends PluginPanel {
         filterSelect.removeAllItems();
         filterSelect.addItem(NONE_ITEM);
         filterSelect.setSelectedIndex(0);
-        plugin.setUserFilters(emptyList());
+        plugin.setUserFilters(new ArrayList<>());
         plugin.setUserFilterIndex(-1);
         updateFilterText(-1);
         invokeLater(() -> filterSelect.addActionListener(this::onFilterSelect));

--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -41,7 +41,6 @@ import java.util.Objects;
 
 import static com.lootfilters.util.FilterUtil.withConfigMatchers;
 import static com.lootfilters.util.TextUtil.quote;
-import static java.util.Collections.emptyList;
 import static net.runelite.client.util.ImageUtil.loadImageResource;
 
 @Slf4j
@@ -100,7 +99,7 @@ public class LootFiltersPlugin extends Plugin {
 	public List<String> getUserFilters() {
 		var cfg = configManager.getConfiguration(CONFIG_GROUP, USER_FILTERS_KEY);
 		if (cfg == null || cfg.isEmpty()) {
-			return emptyList();
+			return new ArrayList<>();
 		}
 
 		var type = new TypeToken<List<String>>(){}.getType();

--- a/src/main/java/com/lootfilters/lang/Preprocessor.java
+++ b/src/main/java/com/lootfilters/lang/Preprocessor.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 import static com.lootfilters.util.CollectionUtil.append;
 import static com.lootfilters.util.TextUtil.normalizeCrlf;
 import static com.lootfilters.util.TextUtil.quote;
-import static java.util.Collections.emptyList;
 
 public class Preprocessor {
     private final TokenStream tokens;
@@ -38,7 +37,7 @@ public class Preprocessor {
             }
         }
 
-        return expandDefines(emptyList(), new TokenStream(preproc)).stream()
+        return expandDefines(new ArrayList<>(), new TokenStream(preproc)).stream()
                 .map(it -> it.is(Token.Type.LITERAL_STRING) ? quote(it.getValue()) : it.getValue())
                 .collect(Collectors.joining(""))
                 .trim();


### PR DESCRIPTION
RuneLite embeds Java 17 for its Mac distribution so this was broken for
most people on Mac OS, and some using 16+ on Windows.

Rather than upgrading GSON we can just not use the java util emptylist()
helper.
