### PR TITLE
Fix Serde Test

### DIFF
--- a/src/main/java/com/lootfilters/DisplayConfig.java
+++ b/src/main/java/com/lootfilters/DisplayConfig.java
@@ -65,7 +65,7 @@ public class DisplayConfig {
         if (menuTextColor != null) {
             return menuTextColor;
         }
-        return textColor != null && textColor.equals(Color.WHITE) ? textColor : DEFAULT_MENU_TEXT_COLOR;
+        return textColor != null && !textColor.equals(Color.WHITE) ? textColor : DEFAULT_MENU_TEXT_COLOR;
     }
 
     public Font getFont() {

--- a/src/main/java/com/lootfilters/DisplayConfig.java
+++ b/src/main/java/com/lootfilters/DisplayConfig.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import net.runelite.client.ui.FontManager;
 
 import java.awt.Color;
@@ -15,6 +16,7 @@ import java.awt.Font;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class DisplayConfig {
     private static final Color DEFAULT_MENU_TEXT_COLOR = Color.decode("#ff9040");
 
@@ -63,7 +65,7 @@ public class DisplayConfig {
         if (menuTextColor != null) {
             return menuTextColor;
         }
-        return textColor != null && textColor != Color.WHITE ? textColor : DEFAULT_MENU_TEXT_COLOR;
+        return textColor != null && textColor.equals(Color.WHITE) ? textColor : DEFAULT_MENU_TEXT_COLOR;
     }
 
     public Font getFont() {

--- a/src/main/java/com/lootfilters/LootFilter.java
+++ b/src/main/java/com/lootfilters/LootFilter.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 
@@ -23,6 +24,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class LootFilter {
     @Setter private String name; // anonymous filter can be imported, would need name
 

--- a/src/main/java/com/lootfilters/MatcherConfig.java
+++ b/src/main/java/com/lootfilters/MatcherConfig.java
@@ -10,6 +10,7 @@ import com.lootfilters.rule.Rule;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 import net.runelite.api.Varbits;
 
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class MatcherConfig {
     private final Rule rule;
     private final DisplayConfig display;

--- a/src/main/java/com/lootfilters/lang/Token.java
+++ b/src/main/java/com/lootfilters/lang/Token.java
@@ -1,6 +1,7 @@
 package com.lootfilters.lang;
 
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import lombok.Value;
 import net.runelite.client.util.ColorUtil;
 

--- a/src/main/java/com/lootfilters/rule/AndRule.java
+++ b/src/main/java/com/lootfilters/rule/AndRule.java
@@ -2,11 +2,13 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class AndRule extends Rule {
     private final List<Rule> rules;
 

--- a/src/main/java/com/lootfilters/rule/ComparatorRule.java
+++ b/src/main/java/com/lootfilters/rule/ComparatorRule.java
@@ -1,8 +1,10 @@
 package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
+@ToString
 public abstract class ComparatorRule extends Rule {
     private final int rhs;
     private final Comparator cmp;

--- a/src/main/java/com/lootfilters/rule/ItemIdRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemIdRule.java
@@ -3,10 +3,12 @@ package com.lootfilters.rule;
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 @Getter
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class ItemIdRule extends Rule {
     private final int id;
 

--- a/src/main/java/com/lootfilters/rule/ItemNameRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemNameRule.java
@@ -2,11 +2,13 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class ItemNameRule extends Rule {
     private final List<String> names;
 

--- a/src/main/java/com/lootfilters/rule/ItemNotedRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemNotedRule.java
@@ -2,9 +2,11 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class ItemNotedRule extends Rule {
     private final boolean target;
 

--- a/src/main/java/com/lootfilters/rule/ItemQuantityRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemQuantityRule.java
@@ -2,9 +2,11 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString(callSuper = true)
 public class ItemQuantityRule extends ComparatorRule {
     public ItemQuantityRule(int value, Comparator cmp) {
         super("item_quantity", value, cmp);

--- a/src/main/java/com/lootfilters/rule/ItemStackableRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemStackableRule.java
@@ -2,10 +2,12 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.ItemID;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class ItemStackableRule extends Rule {
     private final boolean target;
 

--- a/src/main/java/com/lootfilters/rule/ItemTradeableRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemTradeableRule.java
@@ -2,10 +2,12 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.ItemID;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class ItemTradeableRule extends Rule {
     private final boolean target;
 

--- a/src/main/java/com/lootfilters/rule/ItemValueRule.java
+++ b/src/main/java/com/lootfilters/rule/ItemValueRule.java
@@ -2,10 +2,12 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.ItemID;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString(callSuper = true)
 public class ItemValueRule extends ComparatorRule {
     public ItemValueRule(int value, Comparator cmp) {
        super("item_value", value, cmp);

--- a/src/main/java/com/lootfilters/rule/NotRule.java
+++ b/src/main/java/com/lootfilters/rule/NotRule.java
@@ -2,9 +2,11 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class NotRule extends Rule {
     private final Rule inner;
 

--- a/src/main/java/com/lootfilters/rule/OrRule.java
+++ b/src/main/java/com/lootfilters/rule/OrRule.java
@@ -2,11 +2,13 @@ package com.lootfilters.rule;
 
 import com.lootfilters.LootFiltersPlugin;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.runelite.api.TileItem;
 
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class OrRule extends Rule {
     private final List<Rule> rules;
 


### PR DESCRIPTION
The bug's pretty simple `ava.awt.Color` is a class so we can't use simple `!=` syntax to compare it, because that'll use reference equality only.

Digging through I ended up adding ToString to all the various classes involved in the LootFilter so that the test produces a more readable error comparison.

Test passes now.