### PR TITLE
draft: token position for error tracking

### DIFF
--- a/src/main/java/com/lootfilters/LootFilter.java
+++ b/src/main/java/com/lootfilters/LootFilter.java
@@ -1,15 +1,21 @@
 package com.lootfilters;
 
+import static com.lootfilters.lang.Location.UNKNOWN_SOURCE_NAME;
+import static com.lootfilters.util.TextUtil.normalizeCrlf;
+
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.lootfilters.lang.CompileException;
 import com.lootfilters.lang.Lexer;
 import com.lootfilters.lang.Parser;
 import com.lootfilters.lang.Preprocessor;
 import com.lootfilters.lang.Sources;
+import com.lootfilters.lang.TokenStream;
 import com.lootfilters.rule.Rule;
 import com.lootfilters.serde.ColorDeserializer;
 import com.lootfilters.serde.ColorSerializer;
 import com.lootfilters.serde.RuleDeserializer;
+
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,14 +25,18 @@ import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 
 import java.awt.Color;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
 @ToString
 public class LootFilter {
-    @Setter private String name; // anonymous filter can be imported, would need name
+    @Setter
+    private String name; // anonymous filter can be imported, would need name
 
     private final String description;
     private final int[] activationArea;
@@ -40,10 +50,40 @@ public class LootFilter {
         return ggson.fromJson(json, LootFilter.class);
     }
 
+
+    public static LootFilter fromSourcesWithPreamble(Map<String, String> sources) throws CompileException {
+        if (!sources.containsKey("preamble")) {
+            // LinkedHashMap preserves insertion order for iteration ensuring preamble is handled first
+            var withPreamble = new LinkedHashMap<String, String>();
+            withPreamble.put("preamble", Sources.getPreamble());
+            // If iteration order of input map is unstable this may change ordering of input scripts
+            withPreamble.putAll(sources);
+            return fromSources(withPreamble);
+        }
+        return fromSources(new LinkedHashMap<>(sources));
+    }
+
+    public static LootFilter fromSources(LinkedHashMap<String, String> sources) throws CompileException {
+        var combinedStream = sources
+                .entrySet().stream()
+                .map(source -> {
+                    // Do this in 1 map iteration to ensure we preserve iteration order over our input
+                    var sourceValue = source.getValue();
+                    if (!sourceValue.endsWith("\n")) {
+                        sourceValue += "\n";
+                    }
+                    return new Lexer(source.getKey(), normalizeCrlf(sourceValue));
+                })
+                .map(Lexer::tokenize)
+                .flatMap(tokenStream -> tokenStream.getTokens().stream())
+                .collect(Collectors.collectingAndThen(Collectors.toList(), TokenStream::new));
+
+        var postproc = new Preprocessor(combinedStream).preprocess();
+        return new Parser(postproc).parse();
+    }
+
     public static LootFilter fromSource(String source) throws CompileException {
-        var postproc = new Preprocessor(Sources.getPreamble() + "\n" + source).preprocess();
-        var tokens = new Lexer(postproc).tokenize();
-        return new Parser(tokens).parse();
+        return fromSourcesWithPreamble(Map.of(UNKNOWN_SOURCE_NAME, source));
     }
 
     public String toJson(Gson gson) {

--- a/src/main/java/com/lootfilters/LootFiltersPanel.java
+++ b/src/main/java/com/lootfilters/LootFiltersPanel.java
@@ -112,10 +112,8 @@ public class LootFiltersPanel extends PluginPanel {
     private void initControls() throws IOException {
         var filters = plugin.getUserFilters();
         filterSelect.addItem(NONE_ITEM);
-
-        for (int i = 0; i < filters.size(); i++) {
-            var filter = filters.get(i);
-            filterSelect.addItem(LootFilter.fromSourcesWithPreamble(Map.of(UNKNOWN_SOURCE_NAME, filter)).getName());
+        for (var filter : filters) {
+            filterSelect.addItem(LootFilter.fromSource(filter).getName());
         }
 
         var index = plugin.getUserFilterIndex();

--- a/src/main/java/com/lootfilters/LootFiltersPanel.java
+++ b/src/main/java/com/lootfilters/LootFiltersPanel.java
@@ -26,7 +26,10 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static com.lootfilters.lang.Location.UNKNOWN_SOURCE_NAME;
 import static com.lootfilters.util.CollectionUtil.append;
 import static com.lootfilters.util.FilterUtil.configToFilterSource;
 import static com.lootfilters.util.TextUtil.quote;
@@ -109,8 +112,10 @@ public class LootFiltersPanel extends PluginPanel {
     private void initControls() throws IOException {
         var filters = plugin.getUserFilters();
         filterSelect.addItem(NONE_ITEM);
-        for (var filter : filters) {
-            filterSelect.addItem(LootFilter.fromSource(filter).getName());
+
+        for (int i = 0; i < filters.size(); i++) {
+            var filter = filters.get(i);
+            filterSelect.addItem(LootFilter.fromSourcesWithPreamble(Map.of(UNKNOWN_SOURCE_NAME, filter)).getName());
         }
 
         var index = plugin.getUserFilterIndex();
@@ -179,7 +184,7 @@ public class LootFiltersPanel extends PluginPanel {
 
         LootFilter newFilter;
         try {
-            newFilter = LootFilter.fromSource(newSrc);
+            newFilter = LootFilter.fromSourcesWithPreamble(Map.of("clipboard", newSrc));
         } catch (CompileException e) {
             plugin.addChatMessage("Failed to load filter from clipboard: " + e.getMessage());
             return;

--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -36,6 +36,8 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 

--- a/src/main/java/com/lootfilters/lang/Location.java
+++ b/src/main/java/com/lootfilters/lang/Location.java
@@ -1,0 +1,43 @@
+package com.lootfilters.lang;
+
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+@Value
+@RequiredArgsConstructor
+public class Location {
+    public static Location UNKNOWN = new Location("unknown", 0, 0);
+    public static String UNKNOWN_SOURCE_NAME = "unknown";
+
+    String sourceName;
+    int lineNumber;
+    int charNumber;
+    @NonFinal
+    Location macroSourceLocation = null;
+    @NonFinal
+    String macroName = null;
+
+    public Location withMacroName(String name) {
+        var loc = new Location(sourceName, lineNumber, charNumber);
+        loc.macroName = name;
+        return loc;
+    }
+
+    public Location withMacroSourceLocation(Location macroSourceLocation) {
+        var loc = new Location(sourceName, lineNumber, charNumber);
+        loc.macroSourceLocation = macroSourceLocation;
+        return loc;
+    }
+
+    @Override
+    public String toString() {
+        var base = String.format("Location(sourceName=%s, lineNumber=%d, charNumber=%d", sourceName, lineNumber, charNumber);
+        if (macroSourceLocation == null) {
+            return base + ")";
+        } else {
+            return base + ", macroSourceLocation=" + macroSourceLocation + ")";
+        }
+    }
+}

--- a/src/main/java/com/lootfilters/lang/ParseException.java
+++ b/src/main/java/com/lootfilters/lang/ParseException.java
@@ -2,17 +2,56 @@ package com.lootfilters.lang;
 
 import lombok.Getter;
 
+import static com.lootfilters.lang.Location.UNKNOWN_SOURCE_NAME;
+
 @Getter
 public class ParseException extends CompileException {
     private final Token token;
 
     public ParseException(String message, Token token) {
-        super(message + " (token=" + token + ")");
+        super(message + " " + formatToken(token));
         this.token = token;
     }
 
     public ParseException(String message) {
         super(message);
         this.token = null;
+    }
+
+    private static String formatToken(Token token) {
+        // Format a message with source names only if available
+        if (token.getLocation().getMacroSourceLocation() != null) {
+            var tokenLocation = token.getLocation();
+            var macroLocation = tokenLocation.getMacroSourceLocation();
+            var expansionErrorAndLocation = String.format("'%s' after expanding macro %s on L%d, C%d%s.",
+                    token.getValue(),
+                    macroLocation.getMacroName(),
+                    tokenLocation.getLineNumber(),
+                    tokenLocation.getCharNumber(),
+                    sourceNameFragment(tokenLocation.getSourceName()));
+
+            var macroDefineAndMacroErrorLocation = "";
+            if (!macroLocation.getSourceName().equals(UNKNOWN_SOURCE_NAME)) {
+                macroDefineAndMacroErrorLocation = String.format(" %s is defined in '%s', error was on L%d, C%d.",
+                        macroLocation.getMacroName(),
+                        macroLocation.getSourceName(),
+                        macroLocation.getLineNumber(),
+                        macroLocation.getCharNumber()
+                );
+            }
+
+            return expansionErrorAndLocation + macroDefineAndMacroErrorLocation;
+        } else {
+            return String.format("'%s' on L%s, C%s%s",
+                    token.getValue(),
+                    token.getLocation().getLineNumber(),
+                    token.getLocation().getCharNumber(),
+                    sourceNameFragment(token.getLocation().getSourceName())
+            );
+        }
+    }
+
+    private static String sourceNameFragment(String sourceName) {
+        return sourceName.equals(UNKNOWN_SOURCE_NAME) ? "" : String.format(" in '%s'", sourceName);
     }
 }

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -21,6 +21,7 @@ import com.lootfilters.rule.TextAccent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
+import lombok.RequiredArgsConstructor;
 
 import static com.lootfilters.lang.Token.Type.APPLY;
 import static com.lootfilters.lang.Token.Type.ASSIGN;
@@ -44,6 +45,7 @@ import static com.lootfilters.lang.Token.Type.STMT_END;
 
 // Parser somewhat mixes canonical stages 2 (parse) and 3/4 (syntax/semantic analysis) but the filter language is
 // restricted enough that it should be fine for now.
+@RequiredArgsConstructor
 public class Parser {
     private final TokenStream tokens;
     private final List<MatcherConfig> matchers = new ArrayList<>();
@@ -51,10 +53,6 @@ public class Parser {
     private String name;
     private String description;
     private int[] activationArea = null;
-
-    public Parser(List<Token> tokens) {
-        this.tokens = new TokenStream(tokens);
-    }
 
     public LootFilter parse() throws ParseException {
         while (tokens.isNotEmpty()) {

--- a/src/main/java/com/lootfilters/lang/Sources.java
+++ b/src/main/java/com/lootfilters/lang/Sources.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static com.lootfilters.util.TextUtil.normalizeCrlf;
 
@@ -24,7 +26,7 @@ public class Sources {
             preamble = loadScriptResource(preambleStream);
             referenceSource = loadScriptResource(referenceSourceStream);
 
-            referenceFilter = LootFilter.fromSource(referenceSource);
+            referenceFilter = LootFilter.fromSourcesWithPreamble(Map.of("referenceFilter", referenceSource));
         } catch (IOException e) {
             throw new RuntimeException("init static sources", e);
         } catch (CompileException e) {

--- a/src/main/java/com/lootfilters/lang/Token.java
+++ b/src/main/java/com/lootfilters/lang/Token.java
@@ -1,7 +1,6 @@
 package com.lootfilters.lang;
 
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 import lombok.Value;
 import net.runelite.client.util.ColorUtil;
 
@@ -28,12 +27,13 @@ public class Token {
         COMMENT,
     }
 
-    public static Token intLiteral(String value) { return new Token(Type.LITERAL_INT, value); }
-    public static Token stringLiteral(String value) { return new Token(Type.LITERAL_STRING, value); }
-    public static Token identifier(String value) { return new Token(Type.IDENTIFIER, value); }
+    public static Token intLiteral(String value, Location location) { return new Token(Type.LITERAL_INT, value, location); }
+    public static Token stringLiteral(String value, Location location) { return new Token(Type.LITERAL_STRING, value, location); }
+    public static Token identifier(String value, Location location) { return new Token(Type.IDENTIFIER, value, location); }
 
     Type type;
     String value;
+    Location location;
 
     public boolean is(Type type) {
         return this.type == type;
@@ -82,11 +82,19 @@ public class Token {
         return type != Type.COMMENT && !isWhitespace();
     }
 
+    public Token withLocation(Location location) {
+        return new Token(type, value, location);
+    }
+
     @Override
     public String toString() {
         var str = "Token{type=" + type;
         return value != null && value.isEmpty()
                 ? str + "}"
-                : str + ",value=" + value + "}";
+                : str + ",value=" + value + ", location=" + location.toString() + "}";
+    }
+
+    public String formatForException() {
+        return String.format("%s at %s", value, location.toString());
     }
 }

--- a/src/main/java/com/lootfilters/lang/TokenStream.java
+++ b/src/main/java/com/lootfilters/lang/TokenStream.java
@@ -1,5 +1,8 @@
 package com.lootfilters.lang;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 
 import java.util.ArrayList;

--- a/src/test/java/com/lootfilters/ParserTest.java
+++ b/src/test/java/com/lootfilters/ParserTest.java
@@ -2,6 +2,7 @@ package com.lootfilters;
 
 import com.lootfilters.lang.Lexer;
 import com.lootfilters.lang.Parser;
+import com.lootfilters.lang.TokenStream;
 import com.lootfilters.rule.AndRule;
 import com.lootfilters.rule.Comparator;
 import com.lootfilters.rule.ItemNameRule;
@@ -78,8 +79,8 @@ public class ParserTest {
         );
         var expect = new LootFilter(expectName, expectDesc, expectArea, expectMatchers);
 
-        var tokens = new Lexer(input).tokenize();
-        var parser = new Parser(tokens);
+        var lexedTokens = new Lexer("ParserTest", input).tokenize();
+        var parser = new Parser(lexedTokens);
         var actual = parser.parse();
         assertEquals(expect, actual);
     }

--- a/src/test/java/com/lootfilters/PreprocessorTest.java
+++ b/src/test/java/com/lootfilters/PreprocessorTest.java
@@ -1,9 +1,14 @@
 package com.lootfilters;
 
+import com.lootfilters.lang.Lexer;
 import com.lootfilters.lang.Preprocessor;
+import com.lootfilters.lang.Token;
 import org.junit.Test;
 
+import java.util.stream.Collectors;
+
 import static com.lootfilters.TestUtil.loadTestResource;
+import static com.lootfilters.util.TextUtil.quote;
 import static org.junit.Assert.assertEquals;
 
 public class PreprocessorTest {
@@ -12,8 +17,10 @@ public class PreprocessorTest {
         var input = loadTestResource("preprocessor-test-input.rs2f");
         var expect = loadTestResource("preprocessor-test-expect.rs2f");
 
-        var preprocessor = new Preprocessor(input);
-        var actual = preprocessor.preprocess();
+        var preprocessor = new Preprocessor(new Lexer("input", input).tokenize());
+        var actual = preprocessor.preprocess().getTokens().stream()
+                .map(it -> it.is(Token.Type.LITERAL_STRING) ? quote(it.getValue()) : it.getValue())
+                .collect(Collectors.joining(""));
         assertEquals(expect, actual);
     }
 }

--- a/src/test/resources/com/lootfilters/preprocessor-test-expect.rs2f
+++ b/src/test/resources/com/lootfilters/preprocessor-test-expect.rs2f
@@ -1,3 +1,5 @@
+
+
 if (value:>10000000) {
     color = "ff00ff00";
     textColor = "ff00ff00";


### PR DESCRIPTION
## The Feature
Simple, tell you where the error is.
<img width="466" alt="Screenshot 2025-02-20 at 6 49 09 PM" src="https://github.com/user-attachments/assets/50e7a36e-8163-45f9-9185-a0049c0dd68f" />

## Implementation
I embedded a Location within each token during the lexing process. During macro expansion we copy the token - this is less memory efficient, but allows us to update the token that we're inserting (from the macro) to have the location of both the macro, and the position of the token it replaced. 

This means that for an invalid script like:
```
#define FOO(_name) if (name:_name) { \
	unknown = true; \
}

FOO("bar")
```
We can notify the user of where the errored expansion happened _and_ what line in the macro source was the problem. If they're in different sources, then we include that too. 
<img width="466" alt="Screenshot 2025-02-20 at 6 54 54 PM" src="https://github.com/user-attachments/assets/71409aa9-517c-4d6c-ba7c-67e60bd20577" /> 