### PR TITLE
Fixes hidden/highlighted items being fuzzy

### DIFF
--- a/src/main/java/com/lootfilters/util/TextUtil.java
+++ b/src/main/java/com/lootfilters/util/TextUtil.java
@@ -87,7 +87,7 @@ public class TextUtil {
     }
 
     public static String toggleCsv(String csv, String item) {
-        if (csv.contains(item)) {
+        if (Arrays.stream(csv.split(",")).anyMatch(it -> it.trim().equalsIgnoreCase(item))) {
             return unsetCsv(csv, item);
         } else {
             return setCsv(csv, item);


### PR DESCRIPTION
Fixes hidden/highlighted items being fuzzy on the check if it can add new items, preventing something like bones when you had big bones
![Screenshot 2025-02-19 130003](https://github.com/user-attachments/assets/763e69da-ebf4-4194-9143-3a2f7fdf625d)
![Screenshot 2025-02-19 130015](https://github.com/user-attachments/assets/584428c1-e915-407f-9f03-b8f9622eab41)
![Screenshot 2025-02-19 130020](https://github.com/user-attachments/assets/27169819-9740-49b8-8f79-3d49f6ced4fd)
