### PR TITLE
config: deprio/recolor hidden items

### DIFF
--- a/src/main/java/com/lootfilters/DisplayConfig.java
+++ b/src/main/java/com/lootfilters/DisplayConfig.java
@@ -18,7 +18,7 @@ import java.awt.Font;
 @EqualsAndHashCode
 @ToString
 public class DisplayConfig {
-    private static final Color DEFAULT_MENU_TEXT_COLOR = Color.decode("#ff9040");
+    public static final Color DEFAULT_MENU_TEXT_COLOR = Color.decode("#ff9040");
 
     private final Color textColor;
     private final Color backgroundColor;

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -193,6 +193,14 @@ public interface LootFiltersConfig extends Config {
             position = 24
     )
     default boolean highlightTiles() { return false; }
+    @ConfigItem(
+            keyName = "deprioritizeHidden",
+            name = "Deprioritize menu hidden items",
+            description = "Deprioritize menu entries for hidden items.",
+            section = displayOverrides,
+            position = 15
+    )
+    default boolean deprioritizeHidden() { return false; }
 
     @ConfigSection(
             name = "Item lists",

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -195,12 +195,28 @@ public interface LootFiltersConfig extends Config {
     default boolean highlightTiles() { return false; }
     @ConfigItem(
             keyName = "deprioritizeHidden",
-            name = "Deprioritize menu hidden items",
+            name = "Menu: deprioritize hidden items",
             description = "Deprioritize menu entries for hidden items.",
             section = displayOverrides,
             position = 15
     )
     default boolean deprioritizeHidden() { return false; }
+    @ConfigItem(
+            keyName = "recolorHidden",
+            name = "Menu: recolor hidden items",
+            description = "Recolor menu entries for hidden items.",
+            section = displayOverrides,
+            position = 16
+    )
+    default boolean recolorHidden() { return false; }
+    @ConfigItem(
+            keyName = "hiddenColor",
+            name = "Hidden color",
+            description = "Color for hidden items in text overlay and menu entries.",
+            section = displayOverrides,
+            position = 17
+    )
+    default Color hiddenColor() { return Color.GRAY; }
 
     @ConfigSection(
             name = "Item lists",

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -198,7 +198,7 @@ public interface LootFiltersConfig extends Config {
             name = "Menu: deprioritize hidden items",
             description = "Deprioritize menu entries for hidden items.",
             section = displayOverrides,
-            position = 15
+            position = 90
     )
     default boolean deprioritizeHidden() { return false; }
     @ConfigItem(
@@ -206,7 +206,7 @@ public interface LootFiltersConfig extends Config {
             name = "Menu: recolor hidden items",
             description = "Recolor menu entries for hidden items.",
             section = displayOverrides,
-            position = 16
+            position = 91
     )
     default boolean recolorHidden() { return false; }
     @ConfigItem(
@@ -214,7 +214,7 @@ public interface LootFiltersConfig extends Config {
             name = "Hidden color",
             description = "Color for hidden items in text overlay and menu entries.",
             section = displayOverrides,
-            position = 17
+            position = 92
     )
     default Color hiddenColor() { return Color.GRAY; }
 

--- a/src/main/java/com/lootfilters/LootFiltersOverlay.java
+++ b/src/main/java/com/lootfilters/LootFiltersOverlay.java
@@ -41,7 +41,6 @@ public class LootFiltersOverlay extends Overlay {
     private static final int Z_STACK_OFFSET = 16;
     private static final int BOX_PAD = 2;
     private static final int CLICKBOX_SIZE = 8;
-    private static final Color COLOR_HIDDEN = Color.GRAY.brighter();
 
     private final Client client;
     private final LootFiltersPlugin plugin;
@@ -125,7 +124,7 @@ public class LootFiltersOverlay extends Overlay {
 
                 var text = new TextComponent();
                 text.setText(displayText);
-                text.setColor(match.isHidden() ? COLOR_HIDDEN : match.getTextColor());
+                text.setColor(match.isHidden() ? config.hiddenColor() : match.getTextColor());
                 text.setPosition(new Point(textPoint.getX(), textPoint.getY() - currentOffset));
                 if (match.getTextAccentColor() != null) {
                     text.setAccentColor(match.getTextAccentColor());
@@ -150,7 +149,7 @@ public class LootFiltersOverlay extends Overlay {
                 if (plugin.isHotkeyActive() && boundingBox.contains(mouse.getX(), mouse.getY())) {
                     hoveredItem = item.getId();
 
-                    g.setColor(match.isHidden() ? COLOR_HIDDEN : Color.WHITE);
+                    g.setColor(match.isHidden() ? config.hiddenColor() : Color.WHITE);
                     g.drawRect(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
                 }
                 if (config.hotkeyShowClickboxes() && plugin.isHotkeyActive()) {
@@ -312,7 +311,7 @@ public class LootFiltersOverlay extends Overlay {
             onHoverHide.accept(item.getId());
             g.setColor(Color.RED);
         } else {
-            g.setColor(display.isHidden() ? COLOR_HIDDEN : display.getTextColor());
+            g.setColor(display.isHidden() ? config.hiddenColor() : display.getTextColor());
         }
         g.drawRect(hide.x, hide.y, hide.width, hide.height);
         g.setColor(Color.WHITE);
@@ -322,7 +321,7 @@ public class LootFiltersOverlay extends Overlay {
             onHoverHighlight.accept(item.getId());
             g.setColor(Color.GREEN);
         } else {
-            g.setColor(display.isHidden() ? COLOR_HIDDEN : display.getTextColor());
+            g.setColor(display.isHidden() ? config.hiddenColor() : display.getTextColor());
         }
         g.drawRect(show.x, show.y, show.width, show.height);
         g.setColor(Color.WHITE);

--- a/src/main/java/com/lootfilters/MenuEntryComposer.java
+++ b/src/main/java/com/lootfilters/MenuEntryComposer.java
@@ -6,7 +6,6 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 
-import java.awt.Color;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,7 +27,7 @@ public class MenuEntryComposer {
             return;
         }
 
-        entry.setDeprioritized(match.isHidden());
+        entry.setDeprioritized(plugin.getConfig().deprioritizeHidden() && match.isHidden());
         entry.setTarget(buildTargetText(item, match));
     }
 

--- a/src/main/java/com/lootfilters/MenuEntryComposer.java
+++ b/src/main/java/com/lootfilters/MenuEntryComposer.java
@@ -6,10 +6,12 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 
+import java.awt.Color;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.lootfilters.util.TextUtil.abbreviate;
 import static net.runelite.client.util.ColorUtil.colorTag;
 
 @AllArgsConstructor
@@ -24,11 +26,15 @@ public class MenuEntryComposer {
         var item = getItemForEntry(entry);
         var match = plugin.getActiveFilter().findMatch(plugin, item);
         if (match == null) {
+            entry.setTarget(buildTargetText(item, DisplayConfig.DEFAULT_MENU_TEXT_COLOR));
             return;
         }
 
         entry.setDeprioritized(plugin.getConfig().deprioritizeHidden() && match.isHidden());
-        entry.setTarget(buildTargetText(item, match));
+        var color = match.isHidden() && plugin.getConfig().recolorHidden()
+                ? plugin.getConfig().hiddenColor()
+                : match.getMenuTextColor();
+        entry.setTarget(buildTargetText(item, color));
     }
 
     public void onMenuOpened() { // collapse
@@ -60,14 +66,12 @@ public class MenuEntryComposer {
         return plugin.getTileItemIndex().findItem(point, entry.getIdentifier());
     }
 
-    private String buildTargetText(TileItem item, DisplayConfig display) {
+    private String buildTargetText(TileItem item, Color color) {
         var text = plugin.getItemName(item.getId());
         if (item.getQuantity() > 1) {
-            text += " (" + item.getQuantity() + ")";
+            text += " (" + abbreviate(item.getQuantity()) + ")";
         }
-
-        var colorTag = colorTag(display.getMenuTextColor());
-        return colorTag + text;
+        return colorTag(color) + text;
     }
 
     private static boolean isGroundItem(MenuEntry entry) {


### PR DESCRIPTION
Closes #81
Closes #83

Fixes a bug where unmatched items would never get quantity displays in the click menu.