### PR TITLE
fix: add bounds check to prevent plugin crash on startup

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -124,6 +124,10 @@ public class LootFiltersPlugin extends Plugin {
         var index = indexCfg == null || indexCfg.isEmpty()
 				? -1
 				: Integer.parseInt(indexCfg);
+		if (index > getUserFilters().size() -1) {
+			log.warn("User filter index {} is out of bounds, number of filters: {}", index, getUserFilters().size());
+			return -1;
+		}
 		return Math.max(index, -1);
 	}
 


### PR DESCRIPTION
Its possible (though a bug in its own right) to get the current filter index updated but not have the filter save.
In that case we then fail on startup because we get an IndexOutOfBounds trying to load that unsaved filter.

IMO the 'correct' solution here is to not store the 'active' index separately and to just store that also in the same filters list. But that's a problem for another day and a much larger change.

This make it so that if your active index filter is invalid, we just use the default value.