### PR TITLE
single-tap to re-show overlay

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersHotkeyListener.java
+++ b/src/main/java/com/lootfilters/LootFiltersHotkeyListener.java
@@ -35,7 +35,11 @@ public class LootFiltersHotkeyListener extends HotkeyListener {
     }
 
     private boolean shouldToggleOverlay(Instant now) {
-        return plugin.getConfig().hotkeyDoubleTapTogglesOverlay()
-                && Duration.between(lastPressed, now).toMillis() < plugin.getConfig().hotkeyDoubleTapDelay();
+        if (!plugin.getConfig().hotkeyDoubleTapTogglesOverlay()) {
+            return false;
+        }
+
+        return !plugin.isOverlayEnabled() && plugin.isHotkeyActive()
+                || Duration.between(lastPressed, now).toMillis() < plugin.getConfig().hotkeyDoubleTapDelay();
     }
 }


### PR DESCRIPTION
This was double-tap both ways, make re-showing a single tap to have ground items parity.