### PR TITLE
draw LootFiltersOverlay layer above scene

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersOverlay.java
+++ b/src/main/java/com/lootfilters/LootFiltersOverlay.java
@@ -51,6 +51,7 @@ public class LootFiltersOverlay extends Overlay {
     public LootFiltersOverlay(Client client, LootFiltersPlugin plugin, LootFiltersConfig config) {
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
+        setPriority(0.59f);
         this.client = client;
         this.plugin = plugin;
         this.config = config;

--- a/src/main/java/com/lootfilters/LootFiltersOverlay.java
+++ b/src/main/java/com/lootfilters/LootFiltersOverlay.java
@@ -12,6 +12,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 
@@ -49,6 +50,7 @@ public class LootFiltersOverlay extends Overlay {
     @Inject
     public LootFiltersOverlay(Client client, LootFiltersPlugin plugin, LootFiltersConfig config) {
         setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
         this.client = client;
         this.plugin = plugin;
         this.config = config;


### PR DESCRIPTION
[Discord suggestion](https://discord.com/channels/1339305264444080180/1342657875641892894/1342657875641892894)

Changes the overlay layer from UNDER_WIDGETS (default) to ABOVE_SCENE.

This supports the [Improved Tile Indicators](https://github.com/LeikvollE/tileindicators/blob/15cd4fa5dbffbef118b23944113ffa13a207e29e/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsOverlay.java#L67) plugin option to redraw the player above other overlays.

This also has the side effect of overhead prayers drawing above loot filter overlay, which is probably also desirable.