### PR TITLE
Enables compact icon only rendering of ground loot

### DIFF
--- a/src/main/java/com/lootfilters/DisplayConfig.java
+++ b/src/main/java/com/lootfilters/DisplayConfig.java
@@ -28,6 +28,7 @@ public class DisplayConfig {
     private final Boolean hidden;
     private final Boolean showLootbeam;
     private final Boolean showValue;
+    private final Boolean compact;
     private final Boolean showDespawn;
     private final Boolean notify;
     private final TextAccent textAccent;
@@ -52,6 +53,7 @@ public class DisplayConfig {
         hidden = false;
         showLootbeam = false;
         showValue = false;
+        compact = false;
         showDespawn = false;
         notify = false;
         textAccent = null;
@@ -74,6 +76,10 @@ public class DisplayConfig {
 
     public Color getTextColor() {
         return textColor != null ? textColor : Color.WHITE;
+    }
+
+    public BufferedImageProvider getIcon() {
+        return isCompact() ? new BufferedImageProvider.CurrentItem() : icon;
     }
 
     public Color getMenuTextColor() {
@@ -112,6 +118,10 @@ public class DisplayConfig {
     public boolean isHighlightTile() { return !isHidden() && highlightTile != null && highlightTile; }
     public boolean isHideOverlay() { return isHidden() || (hideOverlay != null && hideOverlay); }
 
+    public boolean isCompact() {
+        return !isHidden() && compact != null && compact;
+    }
+
     public DisplayConfig merge(DisplayConfig other) {
         var b = toBuilder();
         if (other.textColor != null) { b.textColor(other.textColor); }
@@ -120,6 +130,7 @@ public class DisplayConfig {
         if (other.hidden != null) { b.hidden(other.hidden); }
         if (other.showLootbeam != null) { b.showLootbeam(other.showLootbeam); }
         if (other.showValue != null) { b.showValue(other.showValue); }
+        if (other.compact != null) { b.compact(other.compact); }
         if (other.showDespawn != null) { b.showDespawn(other.showDespawn); }
         if (other.notify != null) { b.notify(other.notify); }
         if (other.textAccent != null) { b.textAccent(other.textAccent); }

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -212,12 +212,30 @@ public interface LootFiltersConfig extends Config {
             position = 23
     )
     default TextAccent textAccent() { return TextAccent.USE_FILTER; }
+    @Range(min = 16, max = 32)
+    @ConfigItem(
+            keyName = "compactRenderSize",
+            name = "Compact icon height",
+            description = "Icon size for compact item rendering. Specifically, height in pixels, although it will sometimes adjust it slightly to preserve aspect ratio. Full size is 32, a good medium is 26. Valid range is 16-32.",
+            section = displayOverrides,
+            position = 24
+    )
+    default int compactRenderSize() { return 26; }
+    @ConfigItem(
+            keyName = "compactRenderRowLength",
+            name = "Compact row size",
+            description = "How many items to render per row for compact items.",
+            section = displayOverrides,
+            position = 25
+    )
+    @Range(min = 1, max = 128)
+    default int compactRenderRowLength() { return 6; }
     @ConfigItem(
             keyName = "highlightTiles",
             name = "Highlight tiles",
             description = "Always highlight tiles, regardless of filter config.",
             section = displayOverrides,
-            position = 24
+            position = 26
     )
     default boolean highlightTiles() { return false; }
     @ConfigItem(

--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -276,8 +276,11 @@ public class LootFiltersPlugin extends Plugin {
 		if (match.getSound() != null && config.soundVolume() > 0) {
 			queuedAudio.add(match.getSound());
 		}
-		if (match.getIcon() != null) {
+		if (match.getIcon() != null && !match.isCompact()) {
 			iconIndex.inc(match.getIcon(), item);
+		}
+		if(match.isCompact()){
+			iconIndex.inc(match.getIcon(), item,config.compactRenderSize());
 		}
 	}
 
@@ -290,7 +293,7 @@ public class LootFiltersPlugin extends Plugin {
 		lootbeamIndex.remove(tile, item);
 		displayIndex.remove(item);
 		if (display != null && display.getIcon() != null) {
-			iconIndex.dec(display.getIcon(), item);
+			iconIndex.dec(display.getIcon(), item, display.isCompact()? config.compactRenderSize() : 16);
 		}
 	}
 

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -189,6 +189,8 @@ public class Parser {
                     builder.showLootbeam(assign[1].expectBoolean()); break;
                 case "showValue":
                     builder.showValue(assign[1].expectBoolean()); break;
+                case "compact":
+                    builder.compact(assign[1].expectBoolean()); break;
                 case "showDespawn":
                     builder.showDespawn(assign[1].expectBoolean()); break;
                 case "notify":

--- a/src/main/java/com/lootfilters/model/BufferedImageProvider.java
+++ b/src/main/java/com/lootfilters/model/BufferedImageProvider.java
@@ -14,9 +14,10 @@ import static com.lootfilters.LootFiltersPlugin.ICON_DIRECTORY;
 
 @Slf4j
 public abstract class BufferedImageProvider {
-    public abstract BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item);
+    //Height only applies to item icons
+    public abstract BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item, int... height);
 
-    public abstract CacheKey getCacheKey(PluginTileItem item);
+    public abstract CacheKey getCacheKey(PluginTileItem item, int... height);
 
     @AllArgsConstructor
     @EqualsAndHashCode(callSuper = false)
@@ -25,7 +26,7 @@ public abstract class BufferedImageProvider {
         private final int index;
 
         @Override
-        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item) {
+        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item, int... height) {
             try {
                 return plugin.getSpriteManager().getSprite(spriteId, index);
             } catch (ArrayIndexOutOfBoundsException e) {
@@ -35,8 +36,8 @@ public abstract class BufferedImageProvider {
         }
 
         @Override
-        public CacheKey getCacheKey(PluginTileItem item) {
-            return new CacheKey(0, spriteId, index, "");
+        public CacheKey getCacheKey(PluginTileItem item, int... height) {
+            return new CacheKey(0, spriteId, index, "", 16);
         }
     }
 
@@ -46,14 +47,15 @@ public abstract class BufferedImageProvider {
         private final int itemId;
 
         @Override
-        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item) {
+        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item, int... height) {
             var image = plugin.getItemManager().getImage(itemId);
-            return ImageUtil.resizeImage(image, image.getWidth() / 2, image.getHeight() / 2);
+            var imageHeight = height.length >= 1 ? height[0] : 16;
+            return ImageUtil.resizeImage(image, image.getWidth() * imageHeight / image.getHeight(), imageHeight,true);
         }
 
         @Override
-        public CacheKey getCacheKey(PluginTileItem item) {
-            return new CacheKey(1, itemId, 0, "");
+        public CacheKey getCacheKey(PluginTileItem item, int... height) {
+            return new CacheKey(1, itemId, 0, "",height.length >= 1 ? height[0] : 16);
         }
     }
 
@@ -63,7 +65,7 @@ public abstract class BufferedImageProvider {
         private final String filename;
 
         @Override
-        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item) {
+        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item, int... height) {
             try {
                 return ImageIO.read(new java.io.File(ICON_DIRECTORY, filename));
             } catch (Exception e) {
@@ -73,22 +75,23 @@ public abstract class BufferedImageProvider {
         }
 
         @Override
-        public CacheKey getCacheKey(PluginTileItem item) {
-            return new CacheKey(2, 0, 0, filename);
+        public CacheKey getCacheKey(PluginTileItem item, int... height) {
+            return new CacheKey(2, 0, 0, filename,16);
         }
     }
 
     @EqualsAndHashCode(callSuper = false)
     public static final class CurrentItem extends BufferedImageProvider {
         @Override
-        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item) {
+        public BufferedImage getImage(LootFiltersPlugin plugin, PluginTileItem item, int... height) {
             var image = plugin.getItemManager().getImage(item.getId(), item.getQuantity(), false);
-            return ImageUtil.resizeImage(image, image.getWidth() / 2, image.getHeight() / 2);
+            var imageHeight = height.length >= 1 ? height[0] : 16;
+            return ImageUtil.resizeImage(image, image.getWidth() * imageHeight / image.getHeight(), imageHeight,true);
         }
 
         @Override
-        public CacheKey getCacheKey(PluginTileItem item) {
-            return new CacheKey(3, item.getId(), item.getQuantity(), "");
+        public CacheKey getCacheKey(PluginTileItem item, int... height) {
+            return new CacheKey(3, item.getId(), item.getQuantity(), "", height.length >= 1 ? height[0] : 16);
         }
     }
 
@@ -97,5 +100,6 @@ public abstract class BufferedImageProvider {
         int type;
         int param0, param1;
         String param2;
+        int height;
     }
 }

--- a/src/main/java/com/lootfilters/model/DespawnTimerType.java
+++ b/src/main/java/com/lootfilters/model/DespawnTimerType.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 public enum DespawnTimerType {
     TICKS("ticks"),
     SECONDS("seconds"),
-    PIE("pie");
-
+    PIE("pie"),
+    BAR("bar");
     private final String label;
 
     @Override

--- a/src/main/java/com/lootfilters/model/IconIndex.java
+++ b/src/main/java/com/lootfilters/model/IconIndex.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class IconIndex {
@@ -16,10 +17,10 @@ public class IconIndex {
         return index.containsKey(key) ? index.get(key).image : null;
     }
 
-    public void inc(BufferedImageProvider provider, PluginTileItem item) {
-        index.compute(provider.getCacheKey(item), (k, entry) -> {
+    public void inc(BufferedImageProvider provider, PluginTileItem item, int... height) {
+        index.compute(provider.getCacheKey(item, height), (k, entry) -> {
             if (entry == null) {
-                return new CacheEntry(provider.getImage(plugin, item));
+                return new CacheEntry(provider.getImage(plugin, item, height));
             }
 
             ++entry.refCount;
@@ -27,12 +28,11 @@ public class IconIndex {
         });
     }
 
-    public void dec(BufferedImageProvider provider, PluginTileItem item) {
-        index.compute(provider.getCacheKey(item), (k, entry) -> {
+    public void dec(BufferedImageProvider provider, PluginTileItem item, int... height) {
+        index.compute(provider.getCacheKey(item, height), (k, entry) -> {
             if (entry == null) {
                 return null;
             }
-
             --entry.refCount;
             return entry.refCount == 0 ? null : entry;
         });
@@ -52,7 +52,7 @@ public class IconIndex {
             for (var item : entry.getValue()) {
                 var match = plugin.getActiveFilter().findMatch(plugin, item);
                 if (match != null && match.getIcon() != null) {
-                    inc(match.getIcon(), item);
+                    inc(match.getIcon(), item, match.isCompact() ? plugin.getConfig().compactRenderSize() : 16);
                 }
             }
         }


### PR DESCRIPTION
Adds the ability to render ground loot only as icons. These icons are resizeable, and stack under all the non compact items.

This requires a separate render path, and also required sorting the items prior to rendering them. Currently this only sorts the compact items to display before the non compact items, but could easily be expanded to include other sort types.