### PR TITLE
Prototype var-based filtering

### DIFF
--- a/src/main/java/com/lootfilters/ast/leaf/VarCondition.java
+++ b/src/main/java/com/lootfilters/ast/leaf/VarCondition.java
@@ -1,0 +1,24 @@
+package com.lootfilters.ast.leaf;
+
+import com.lootfilters.LootFiltersPlugin;
+import com.lootfilters.ast.LeafCondition;
+import com.lootfilters.model.PluginTileItem;
+import com.lootfilters.model.VarTransform;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class VarCondition extends LeafCondition {
+    private final int varId;
+    private final VarTransform transform;
+    private final boolean useVarbit;
+
+    @Override
+    public boolean test(LootFiltersPlugin plugin, PluginTileItem item) {
+        int value = useVarbit
+                ? plugin.getClient().getVarbitValue(varId)
+                : plugin.getClient().getVarpValue(varId);
+        return transform.apply(value) != 0;
+    }
+}

--- a/src/main/java/com/lootfilters/lang/Lexer.java
+++ b/src/main/java/com/lootfilters/lang/Lexer.java
@@ -26,12 +26,16 @@ public class Lexer {
         put("if", Token.Type.IF);
         put("&&", Token.Type.OP_AND);
         put("||", Token.Type.OP_OR);
+        put(">>", Token.Type.OP_RSHIFT);
+        put("<<", Token.Type.OP_LSHIFT);
         put(">=", Token.Type.OP_GTEQ);
         put("<=", Token.Type.OP_LTEQ);
         put("==", Token.Type.OP_EQ);
         put("!", Token.Type.OP_NOT);
         put(">", Token.Type.OP_GT);
         put("<", Token.Type.OP_LT);
+        put("&", Token.Type.OP_BITAND);
+        put("|", Token.Type.OP_BITOR);
         put(";", Token.Type.STMT_END);
         put(":", Token.Type.COLON);
         put("=", Token.Type.ASSIGN);

--- a/src/main/java/com/lootfilters/lang/Parser.java
+++ b/src/main/java/com/lootfilters/lang/Parser.java
@@ -6,6 +6,7 @@ import com.lootfilters.FilterRule;
 import com.lootfilters.model.SoundProvider;
 import com.lootfilters.model.BufferedImageProvider;
 import com.lootfilters.ast.leaf.AccountTypeCondition;
+import com.lootfilters.ast.leaf.VarCondition;
 import com.lootfilters.ast.AndCondition;
 import com.lootfilters.ast.leaf.AreaCondition;
 import com.lootfilters.model.Comparator;
@@ -25,11 +26,14 @@ import com.lootfilters.ast.OrCondition;
 import com.lootfilters.ast.Condition;
 import com.lootfilters.model.TextAccent;
 import com.lootfilters.model.ValueType;
+import com.lootfilters.model.VarTransform;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.coords.WorldPoint;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 
 import static com.lootfilters.lang.Token.Type.APPLY;
@@ -66,6 +70,7 @@ public class Parser {
     private final TokenStream tokens;
 
     private final LootFilter.Builder builder = LootFilter.builder();
+    private final Map<String, VarTransform> varTransforms = new HashMap<>();
 
     public LootFilter parse() throws ParseException {
         while (tokens.isNotEmpty()) {
@@ -76,6 +81,8 @@ public class Parser {
                 parseRule(true, tok.getLocation().getLineNumber());
             } else if (tok.is(APPLY)) {
                 parseRule(false, tok.getLocation().getLineNumber());
+            } else if (tok.is(IDENTIFIER) && tok.getValue().equals("varexpr")) {
+                parseVarExpr();
             } else {
                 throw new ParseException("unexpected token", tok);
             }
@@ -259,6 +266,10 @@ public class Parser {
                 return parseAreaRule();
             case "accountType":
                 return parseAccountTypeRule();
+            case "var":
+                return parseVarRule(false);
+            case "varbit":
+                return parseVarRule(true);
             default:
                 throw new ParseException("unknown rule identifier", first);
         }
@@ -330,6 +341,58 @@ public class Parser {
     private AccountTypeCondition parseAccountTypeRule() {
         var type = tokens.takeExpect(LITERAL_INT).expectInt();
         return new AccountTypeCondition(type);
+    }
+
+    private void parseVarExpr() {
+        var nameToken = tokens.takeExpect(IDENTIFIER);
+        var name = nameToken.getValue();
+        tokens.takeExpect(COLON);
+
+        var vToken = tokens.takeExpect(IDENTIFIER);
+        if (!vToken.getValue().equals("v")) {
+            throw new ParseException("varexpr must start with 'v'", vToken);
+        }
+
+        var ops = new ArrayList<VarTransform.Op>();
+        while (tokens.isNotEmpty() && isBitwiseOp(tokens.peek())) {
+            var op = tokens.take();
+            var operand = tokens.takeExpect(LITERAL_INT).expectInt();
+            ops.add(new VarTransform.Op(toBitwiseOpType(op), operand));
+        }
+
+        varTransforms.put(name, new VarTransform(ops));
+    }
+
+    private VarCondition parseVarRule(boolean useVarbit) {
+        var next = tokens.peek();
+        if (next.is(IDENTIFIER)) {
+            var name = tokens.take().getValue();
+            var transform = varTransforms.get(name);
+            if (transform == null) {
+                throw new ParseException("unknown varexpr '" + name + "'", next);
+            }
+            var varId = tokens.takeExpect(LITERAL_INT).expectInt();
+            return new VarCondition(varId, transform, useVarbit);
+        } else if (next.is(LITERAL_INT)) {
+            var varId = tokens.take().expectInt();
+            return new VarCondition(varId, VarTransform.IDENTITY, useVarbit);
+        }
+        throw new ParseException("var: expected transform name or var id", next);
+    }
+
+    private boolean isBitwiseOp(Token tok) {
+        return tok.is(Token.Type.OP_RSHIFT) || tok.is(Token.Type.OP_LSHIFT)
+                || tok.is(Token.Type.OP_BITAND) || tok.is(Token.Type.OP_BITOR);
+    }
+
+    private VarTransform.OpType toBitwiseOpType(Token tok) {
+        switch (tok.getType()) {
+            case OP_RSHIFT: return VarTransform.OpType.RSHIFT;
+            case OP_LSHIFT: return VarTransform.OpType.LSHIFT;
+            case OP_BITAND: return VarTransform.OpType.BITAND;
+            case OP_BITOR:  return VarTransform.OpType.BITOR;
+            default: throw new ParseException("expected bitwise operator", tok);
+        }
     }
 
     private Condition buildRule(List<Condition> postfix) {

--- a/src/main/java/com/lootfilters/lang/Token.java
+++ b/src/main/java/com/lootfilters/lang/Token.java
@@ -19,6 +19,7 @@ public class Token {
         LITERAL_INT, LITERAL_STRING,
         ASSIGN,
         OP_EQ, OP_GT, OP_LT, OP_GTEQ, OP_LTEQ, OP_AND, OP_OR, OP_NOT,
+        OP_RSHIFT, OP_LSHIFT, OP_BITAND, OP_BITOR,
         EXPR_START, EXPR_END,
         BLOCK_START, BLOCK_END,
         LIST_START, LIST_END,

--- a/src/main/java/com/lootfilters/model/VarTransform.java
+++ b/src/main/java/com/lootfilters/model/VarTransform.java
@@ -1,0 +1,43 @@
+package com.lootfilters.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@AllArgsConstructor
+public class VarTransform {
+    public static final VarTransform IDENTITY = new VarTransform(Collections.emptyList());
+
+    @Getter
+    private final List<Op> ops;
+
+    public int apply(int value) {
+        for (var op : ops) {
+            value = op.apply(value);
+        }
+        return value;
+    }
+
+    public enum OpType {
+        RSHIFT, LSHIFT, BITAND, BITOR
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Op {
+        private final OpType type;
+        private final int operand;
+
+        public int apply(int value) {
+            switch (type) {
+                case RSHIFT: return value >> operand;
+                case LSHIFT: return value << operand;
+                case BITAND: return value & operand;
+                case BITOR:  return value | operand;
+                default: return value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Huzzah, it works. Likely not merge ready, but just for you to see what the prototype looks like.

### Testcase: Dropping bones every tile while turning pray on/off
Proof that var changes are working, even though no access to leagues world.
<img width="988" height="490" alt="image" src="https://github.com/user-attachments/assets/f306d996-126c-4524-a3ad-81de4a9f7d57" />

### Questions for you
#### varexpr in preamble
Should common transforms (bit0-bit31) be defined in `preamble.rs2f` so all filters can use them? Or left to filter authors?
#### Newline termination
Does `varexpr bit9: v >> 9 & 1` end at newline, or need a `;`? Currently it just reads tokens until it hits something that's not a bitwise op, which works but isn't explicit.
#### Operator precedence
Left-to-right chain (how it's implemented now) or C-standard (`>>` before `&` before `|`)? Current behavior: `v >> 9 & 1` = `(v >> 9) & 1` which happens to be the same either way, but `v & 3 | 4` would differ.
### Testing filter used.
```
meta {
  name = "Var Condition Test";
  description = "Tests varexpr/var/varbit conditions using toggleable game state. Toggle quick prayers and run to see changes live.";
}

// === TRANSFORM DECLARATIONS ===
varexpr bit0: v & 1
varexpr bit1: v >> 1 & 1
varexpr bit2: v >> 2 & 1

// === Controllable varbits ===
// Varbit 4103 = QUICKPRAYER_ACTIVE (toggle via prayer orb)
// Varbit 25   = STAMINA_ACTIVE (drink a stamina pot, or 0 if none active)

// === TEST 1: varbit true/false ===
// Bones highlight GREEN when quick prayers are ON, no highlight when OFF
apply (id:526 && varbit:4103) {
  color = GREEN;
  showLootbeam = true;
  lootbeamColor = GREEN;
}

// === TEST 2: negated varbit ===
// Feathers highlight RED when quick prayers are OFF, no highlight when ON
apply (id:314 && !varbit:4103) {
  color = RED;
  showLootbeam = true;
  lootbeamColor = RED;
}

// === TEST 3: varbit with transform ===
// Quick prayer varbit is 0 or 1. bit0 extraction should behave the same.
// Coins highlight CYAN when quick prayers are ON
apply (id:995 && varbit:bit0 4103) {
  color = CYAN;
  showLootbeam = true;
  lootbeamColor = CYAN;
}

// === TEST 4: varp with bit extraction (combat achievements) ===
// Varp 3116 = first combat achievement varp (32 tasks packed)
// Iron arrows highlight MAGENTA if combat achievement task 0 is complete
apply (id:884 && var:bit0 3116) {
  color = MAGENTA;
}

// Bronze arrows highlight YELLOW if task 1 is complete
apply (id:882 && var:bit1 3116) {
  color = YELLOW;
}

// === TEST 5: negated varp bit (incomplete task pattern) ===
// Raw trout highlights WHITE if combat achievement task 2 is NOT complete
// This is the exact pattern for leagues: highlight items for incomplete tasks
apply (id:335 && !var:bit2 3116) {
  color = WHITE;
  showLootbeam = true;
  lootbeamColor = WHITE;
}

// === TEST 6: multiple conditions combined ===
// Raw shrimp highlights BLUE only when: quick prayers ON AND task 0 complete
apply (id:317 && varbit:4103 && var:bit0 3116) {
  color = BLUE;
  showLootbeam = true;
  lootbeamColor = BLUE;
}
```