### PR TITLE
Fix analyzer chat messages not appearing until next chat event

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -374,6 +374,7 @@ public class LootFiltersPlugin extends Plugin {
 			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", chatMsg, "loot-filters", false);
 		}
 		queuedChatMessages.clear();
+		clientThread.invokeLater(client::refreshChat);
 	}
 
 	private void clearIndices() {


### PR DESCRIPTION
When prototyping the leagues varbit filtering, I noticed the right-click analyze wasn't printing correctly.

Chat messages queued via `addChatMessage()` weren't visually appearing until another chat event triggered a widget redraw, like examining an item. Then all queued analyzer messages would fire before it. `client.addChatMessage()` updates the chat model but doesn't repaint the chatbox widget. 

Added `client.refreshChat()` after flushing queued messages (deferred). This matches how RuneLite's own `ChatMessageManager` handles it.