### PR TITLE
Fix tradeable item detection

### DIFF
--- a/src/main/java/com/lootfilters/model/PluginTileItem.java
+++ b/src/main/java/com/lootfilters/model/PluginTileItem.java
@@ -40,7 +40,7 @@ public class PluginTileItem {
         this.despawnInstant = Instant.now().plusMillis((getDespawnTime() - spawnTime) * 600L);
         this.isStackable = composition.isStackable();
         this.isNoted = composition.getNote() != -1;
-        this.isTradeable = composition.isTradeable() || linkedNoteComposition.isTradeable();
+        this.isTradeable = composition.isTradeable() || (linkedNoteComposition.getId() != -1 && linkedNoteComposition.isTradeable());
         this.tile = tile;
         this.worldView = tile.getItemLayer().getWorldView().getId();
     }


### PR DESCRIPTION
Dont know where exactly does this issue originate from or how long it has been around, but looks like when you call `getLinkedNoteId()` on an item that cannot be noted it returns `-1`, and the `isTradeable()` method on the ItemComposition with id -1 seems to always return true.
So my quick solution to fix the issue would be checking the id of the linkedNoteComposition before the isTradeable check.

`this.isTradeable = composition.isTradeable() || linkedNoteComposition.isTradeable();`
  -->
`this.isTradeable = composition.isTradeable() || (linkedNoteComposition.getId() != -1 && linkedNoteComposition.isTradeable());`