### PR TITLE
Allow customizing system notifications

### DIFF
--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -340,6 +340,14 @@ public interface LootFiltersConfig extends Config {
     default LootbeamHeight lootbeamHeight() {
         return LootbeamHeight.NORMAL;
     }
+    @ConfigItem(
+        keyName = "customSystemNotification",
+        name = "Customized system notifications",
+        description = "Customize system notifications sent.",
+        section = displayOverrides,
+        position = 201
+    )
+    default Notification customSystemNotification() { return Notification.OFF; }
 
     @ConfigSection(
             name = "Global filters",
@@ -422,29 +430,21 @@ public interface LootFiltersConfig extends Config {
             position = 4
     )
     default boolean highlightNotify() { return false; }
-    @ConfigItem(
-        keyName = "customSystemNotification",
-        name = "Customized system notifications",
-        description = "Customize system notifications sent.",
-        section = itemLists,
-        position = 5
-    )
-    default Notification customSystemNotification() { return Notification.OFF; }
-    @ConfigItem(position = 6, section = itemLists,
+    @ConfigItem(position = 5, section = itemLists,
             keyName = "hdBackgroundColor", name = "Background", description = "")
     @Alpha default Color higlightBackgroundColor() { return null; }
-    @ConfigItem(position = 7, section = itemLists,
+    @ConfigItem(position = 6, section = itemLists,
             keyName = "hdBorderColor", name = "Border", description = "")
     @Alpha default Color highlightBorderColor() { return Color.decode("#aa00ff"); }
-    @ConfigItem(position = 8, section = itemLists,
+    @ConfigItem(position = 7, section = itemLists,
             keyName = "hdLootbeamColor", name = "Lootbeam", description = "")
     @Alpha default Color highlightLootbeamColor() { return null; }
-    @ConfigItem(position = 9, section = itemLists,
+    @ConfigItem(position = 8, section = itemLists,
             keyName = "hdMenuTextColor", name = "Menu text", description = "")
     @Alpha default Color highlightMenuTextColor() { return null; }
-    @ConfigItem(position = 10, section = itemLists, keyName = "hdMenuSort", name = "Menu sort priority", description = "")
+    @ConfigItem(position = 9, section = itemLists, keyName = "hdMenuSort", name = "Menu sort priority", description = "")
     default int highlightMenuSort() { return 0; }
-    @ConfigItem(position = 11, section = itemLists,
+    @ConfigItem(position = 10, section = itemLists,
             keyName = "hdSound", name = "Sound", description = "Can be one of two types of values:<br><br>A number: play a game sound effect by ID<br>A string: play a custom audio file from .runelite/loot-filters/sounds, not all sound formats are supported")
     default String highlightSound() { return ""; }
 

--- a/src/main/java/com/lootfilters/LootFiltersConfig.java
+++ b/src/main/java/com/lootfilters/LootFiltersConfig.java
@@ -13,6 +13,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Notification;
 import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
 
@@ -421,21 +422,29 @@ public interface LootFiltersConfig extends Config {
             position = 4
     )
     default boolean highlightNotify() { return false; }
-    @ConfigItem(position = 5, section = itemLists,
+    @ConfigItem(
+        keyName = "customSystemNotification",
+        name = "Customized system notifications",
+        description = "Customize system notifications sent.",
+        section = itemLists,
+        position = 5
+    )
+    default Notification customSystemNotification() { return Notification.OFF; }
+    @ConfigItem(position = 6, section = itemLists,
             keyName = "hdBackgroundColor", name = "Background", description = "")
     @Alpha default Color higlightBackgroundColor() { return null; }
-    @ConfigItem(position = 6, section = itemLists,
+    @ConfigItem(position = 7, section = itemLists,
             keyName = "hdBorderColor", name = "Border", description = "")
     @Alpha default Color highlightBorderColor() { return Color.decode("#aa00ff"); }
-    @ConfigItem(position = 7, section = itemLists,
+    @ConfigItem(position = 8, section = itemLists,
             keyName = "hdLootbeamColor", name = "Lootbeam", description = "")
     @Alpha default Color highlightLootbeamColor() { return null; }
-    @ConfigItem(position = 8, section = itemLists,
+    @ConfigItem(position = 9, section = itemLists,
             keyName = "hdMenuTextColor", name = "Menu text", description = "")
     @Alpha default Color highlightMenuTextColor() { return null; }
-    @ConfigItem(position = 9, section = itemLists, keyName = "hdMenuSort", name = "Menu sort priority", description = "")
+    @ConfigItem(position = 10, section = itemLists, keyName = "hdMenuSort", name = "Menu sort priority", description = "")
     default int highlightMenuSort() { return 0; }
-    @ConfigItem(position = 10, section = itemLists,
+    @ConfigItem(position = 11, section = itemLists,
             keyName = "hdSound", name = "Sound", description = "Can be one of two types of values:<br><br>A number: play a game sound effect by ID<br>A string: play a custom audio file from .runelite/loot-filters/sounds, not all sound formats are supported")
     default String highlightSound() { return ""; }
 

--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -313,8 +313,9 @@ public class LootFiltersPlugin extends Plugin {
 		if (match.isNotify()) {
 			if (config.customSystemNotification().isEnabled()) {
 				notifier.notify(config.customSystemNotification(), "[Loot Filters] You received a drop: " + item.getName());
+			} else {
+				notifier.notify("[Loot Filters] You received a drop: " + item.getName());
 			}
-			notifier.notify("[Loot Filters] You received a drop: " + item.getName());
 		}
 		if (match.getSound() != null && config.soundVolume() > 0) {
 			queuedAudio.add(match.getSound());

--- a/src/main/java/com/lootfilters/LootFiltersPlugin.java
+++ b/src/main/java/com/lootfilters/LootFiltersPlugin.java
@@ -311,6 +311,9 @@ public class LootFiltersPlugin extends Plugin {
 			lootbeamIndex.put(tile, item, beam);
 		}
 		if (match.isNotify()) {
+			if (config.customSystemNotification().isEnabled()) {
+				notifier.notify(config.customSystemNotification(), "[Loot Filters] You received a drop: " + item.getName());
+			}
 			notifier.notify("[Loot Filters] You received a drop: " + item.getName());
 		}
 		if (match.getSound() != null && config.soundVolume() > 0) {


### PR DESCRIPTION
Adds new config item that allows user to customize the system notifications the plugin sends instead of relying on the Runelite global config.

<img width="260" height="409" alt="image" src="https://github.com/user-attachments/assets/a42d61ae-80ff-4040-b7dd-4cb2a31e19b7" />